### PR TITLE
プロジェクトの変更を常時受け取るように変更

### DIFF
--- a/lib/entity/project_user.dart
+++ b/lib/entity/project_user.dart
@@ -4,6 +4,7 @@ import 'package:projecthit/entity/project_user_field.dart';
 class ProjectUser {
   String id;
   String userId;
+  DocumentReference projectRef;
   Timestamp createdAt;
 
   ProjectUser();
@@ -11,6 +12,7 @@ class ProjectUser {
   ProjectUser.fromMap(Map<String, dynamic> map) {
     id = map[ProjectUserField.id];
     userId = map[ProjectUserField.userId];
+    projectRef = map[ProjectUserField.projectRef];
     createdAt = map[ProjectUserField.createdAt];
   }
 

--- a/lib/entity/project_user_field.dart
+++ b/lib/entity/project_user_field.dart
@@ -1,5 +1,6 @@
 class ProjectUserField {
   static const id = 'id';
   static const userId = 'userId';
+  static const projectRef = 'projectRef';
   static const createdAt = 'createdAt';
 }

--- a/lib/repository/project_repository.dart
+++ b/lib/repository/project_repository.dart
@@ -2,29 +2,21 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:projecthit/entity/project.dart';
+import 'package:projecthit/entity/project_field.dart';
 import 'package:projecthit/entity/project_user.dart';
 
 class ProjectRepository {
   final _store = FirebaseFirestore.instance;
   final _auth = FirebaseAuth.instance;
 
-  Future<List<Project>> fetchProjects() async {
-    final projectUsersSnapshot = await _store
-        .collectionGroup('projectUsers')
-        .where('userId', isEqualTo: _auth.currentUser.uid)
-        .orderBy('createdAt', descending: true)
-        .get();
-    final projects = await Future.wait(
-      projectUsersSnapshot.docs.map(
-        (doc) async {
-          final projectSnapshot = await doc.reference.parent.parent.get();
-          final data = projectSnapshot.data();
-          data['id'] = projectSnapshot.id;
-          return Project.fromMap(data);
-        },
-      ),
+  Stream<Project> fetchProject(ProjectUser projectUser) {
+    return projectUser.projectRef.snapshots().map(
+      (snapshot) {
+        final data = snapshot.data();
+        data[ProjectField.id] = snapshot.id;
+        return Project.fromMap(data);
+      },
     );
-    return projects;
   }
 
   Future<String> addProject({@required Project project}) async {

--- a/lib/repository/project_user_repository.dart
+++ b/lib/repository/project_user_repository.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:projecthit/entity/project_user.dart';
+import 'package:projecthit/entity/project_user_field.dart';
+
+class ProjectUserRepository {
+  final _store = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
+
+  Stream<List<ProjectUser>> fetchProjectUsers() {
+    final projectUserSnapshots = _store
+        .collectionGroup('projectUsers')
+        .where('userId', isEqualTo: _auth.currentUser.uid)
+        .orderBy('createdAt', descending: true)
+        .snapshots();
+    return projectUserSnapshots.map(
+      (snapshot) {
+        return snapshot.docs.map(
+          (doc) {
+            final data = doc.data();
+            data[ProjectUserField.id] = doc.id;
+            data[ProjectUserField.projectRef] = doc.reference.parent.parent;
+            return ProjectUser.fromMap(data);
+          },
+        ).toList();
+      },
+    );
+  }
+}

--- a/lib/screens/project_list/project_list_model.dart
+++ b/lib/screens/project_list/project_list_model.dart
@@ -1,13 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:projecthit/entity/project.dart';
+import 'package:projecthit/entity/project_user.dart';
 import 'package:projecthit/repository/project_repository.dart';
+import 'package:projecthit/repository/project_user_repository.dart';
 
 class ProjectListModel extends ChangeNotifier {
   final _projectRepository = ProjectRepository();
-  List<Project> projects = [];
+  final _projectUserRepository = ProjectUserRepository();
 
-  Future<void> fetchUserProjects() async {
-    projects = await _projectRepository.fetchProjects();
-    notifyListeners();
+  Stream<List<ProjectUser>> fetchProjectUsers() {
+    return _projectUserRepository.fetchProjectUsers();
+  }
+
+  Stream<Project> fetchProject(ProjectUser projectUser) {
+    return _projectRepository.fetchProject(projectUser);
   }
 }


### PR DESCRIPTION
## 作業内容
ある時点でのプロジェクトを取得するのでなく、変更が行われたら即反映されるように変更

## 変更理由
プロジェクトに参加している他のメンバーがプロジェクトを編集した際にメンバー間で同期されるようにしたい。

## 確認手順
1. アプリが起動すると参加中のプロジェクトを表示される。
2. プロジェクトを新規作成し、前の画面に戻ると新しいプロジェクトが表示されている。

## Issue
#55 