### PR TITLE
プロジェクト更新後のタイトルが変わらないバグを解決

### DIFF
--- a/lib/screens/project_list/project_list_page.dart
+++ b/lib/screens/project_list/project_list_page.dart
@@ -3,6 +3,7 @@ import 'package:outline_material_icons/outline_material_icons.dart';
 import 'package:projecthit/entity/project.dart';
 import 'package:projecthit/entity/project_user.dart';
 import 'package:projecthit/screens/add_project/add_project_page.dart';
+import 'package:projecthit/screens/project_detail/project_detail_page.dart';
 import 'package:projecthit/screens/project_list/project_list_model.dart';
 import 'package:projecthit/screens/setting/setting_page.dart';
 import 'package:projecthit/screens/task_list/task_list_page.dart';
@@ -146,6 +147,21 @@ class ProjectList extends StatelessWidget {
                                         ),
                                       ),
                                     ],
+                                  ),
+                                ),
+                                SizedBox(
+                                  width: 32,
+                                  child: IconButton(
+                                    icon: Icon(Icons.more_vert),
+                                    onPressed: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              ProjectDetail(project: project),
+                                        ),
+                                      );
+                                    },
                                   ),
                                 ),
                               ],

--- a/lib/screens/task_list/task_list_page.dart
+++ b/lib/screens/task_list/task_list_page.dart
@@ -4,8 +4,6 @@ import 'package:projecthit/extension/date_time.dart';
 import 'package:projecthit/entity/project.dart';
 import 'package:projecthit/entity/task.dart';
 import 'package:projecthit/screens/add_task/add_task_page.dart';
-import 'package:projecthit/screens/invite_member/invite_member_page.dart';
-import 'package:projecthit/screens/project_detail/project_detail_page.dart';
 import 'package:projecthit/screens/task_detail/task_detail_page.dart';
 import 'package:projecthit/screens/task_list/task_list_model.dart';
 import 'package:provider/provider.dart';
@@ -54,7 +52,6 @@ class TaskList extends StatelessWidget {
           appBar: AppBar(
             title: Column(
               mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   '${project.name}',
@@ -69,34 +66,6 @@ class TaskList extends StatelessWidget {
                 ),
               ],
             ),
-            actions: [
-              IconButton(
-                icon: Icon(Icons.person_add_outlined),
-                onPressed: () {
-                  showModalBottomSheet(
-                    context: context,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.vertical(
-                        top: Radius.circular(16),
-                      ),
-                    ),
-                    builder: (context) => InviteMember(),
-                  );
-                },
-              ),
-              IconButton(
-                icon: Icon(Icons.more_vert),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      fullscreenDialog: true,
-                      builder: (context) => ProjectDetail(project: project),
-                    ),
-                  );
-                },
-              ),
-            ],
           ),
           body: StreamBuilder(
             stream: taskListModel.fetchTasks(),


### PR DESCRIPTION
## 作業内容
- プロジェクト詳細画面の表示方法を変更。プロジェクト一覧画面のリストに表示されているアイコンをタップして表示するようにした。
- 上記により、タスク一覧画面のヘッダーに配置したアイコンボタンを削除した。

## 確認手順
1. プロジェクト一覧画面＞プロジェクト詳細画面に移動
2. プロジェクト名を変更し保存すると画面が元に戻る
3. プロジェクト一覧画面およびタスク詳細画面でプロジェクト名およびその他の変更が反映されている

## Issue
#61 