### PR TITLE
プロジェクト削除機能を作成

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -49,8 +49,12 @@ service cloud.firestore {
         && request.resource.data.sumUsers >= 1
         && request.resource.data.createdAt is timestamp
         && request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if isAnyAuthenticated()
+        && resource.data.adminUser == request.auth.uid;
 
       match /projectUsers/{projectUserId} {
+        allow list: if isAnyAuthenticated()
+          && exists(/databases/$(database)/documents/projects/$(projectId)/projectUsers/$(request.auth.uid));
         allow create: if isAnyAuthenticated()
           && existsAfter(/databases/$(database)/documents/projects/$(projectId))
           && request.resource.data.keys().hasAll(['userId', 'createdAt'])
@@ -59,6 +63,8 @@ service cloud.firestore {
           && request.resource.data.userId == request.auth.uid
           && request.resource.data.createdAt is timestamp
           && request.resource.data.createdAt == request.time;
+        allow delete: if isAnyAuthenticated()
+          && (request.auth.uid == get(/databases/$(database)/documents/projects/$(projectId)).data.adminUser || request.auth.uid == resource.data.userId);
       }
 
       match /projectTasks/{projectTaskId} {

--- a/lib/screens/project_detail/project_detail_model.dart
+++ b/lib/screens/project_detail/project_detail_model.dart
@@ -26,6 +26,10 @@ class ProjectDetailModel extends ChangeNotifier {
     await _projectRepository.updateProject(project: project);
   }
 
+  Future<void> deleteProject({@required Project project}) async {
+    await _projectRepository.deleteProject(project: project);
+  }
+
   @override
   void dispose() {
     deadlineController.dispose();

--- a/lib/screens/project_detail/project_detail_page.dart
+++ b/lib/screens/project_detail/project_detail_page.dart
@@ -57,18 +57,81 @@ class ProjectDetail extends StatelessWidget {
     }
   }
 
+  Future<void> _confirmDeletingProject(
+    BuildContext context,
+    ProjectDetailModel projectDetailModel,
+  ) async {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Are you sure?'),
+          content: Text(
+              'Delete this project and related tasks. you can\'t recover deleted project later.'),
+          actions: [
+            TextButton(
+              child: Text('cancel'.toUpperCase()),
+              onPressed: () => Navigator.pop(context),
+            ),
+            TextButton(
+              child: Text('delete'.toUpperCase()),
+              onPressed: () async {
+                Navigator.pop(context);
+                await _deleteProject(context, projectDetailModel);
+              },
+            )
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _deleteProject(
+    BuildContext context,
+    ProjectDetailModel projectDetailModel,
+  ) async {
+    try {
+      projectDetailModel.beginLoading();
+      await projectDetailModel.deleteProject(project: project);
+      projectDetailModel.endLoading();
+
+      Navigator.pop(context);
+    } catch (e) {
+      projectDetailModel.endLoading();
+      showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: Text('Oops!'),
+            content: Text('$e'),
+            actions: [
+              TextButton(
+                child: Text('OK'),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          );
+        },
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<ProjectDetailModel>(
       create: (_) => ProjectDetailModel(),
       builder: (context, child) {
+        final projectDetailModel = context.read<ProjectDetailModel>();
+
         return Scaffold(
           appBar: AppBar(
             actions: [
               IconButton(
                 icon: Icon(Icons.delete_outline),
-                onPressed: () {
-                  // TODO: プロジェクト削除
+                onPressed: () async {
+                  await _confirmDeletingProject(context, projectDetailModel);
                 },
               ),
               IconButton(


### PR DESCRIPTION
## 作業内容
プロジェクト削除機能を作成

- [x] プロジェクトを作成した本人だけが削除できる。
- [x] プロジェクトメンバーは削除はできないが退出は可能（未実装）
- [x] プロジェクトを削除すると、関連するユーザー、タスクは全て削除される。

## 確認手順
1. プロジェクト詳細画面でゴミ箱アイコンを押すとダイアログが表示される。
2. DELETEボタンを押すとプロジェクトを削除され、関連するデータも削除される。
3. 削除に成功するとダイアログが閉じ前の画面に戻る。

## Issue
#63 