### PR TITLE
プロフィール写真変更機能の作成

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="@string/app_name"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -71,6 +71,9 @@ PODS:
   - GoogleUtilities/Reachability (7.2.2):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.5.0)
+  - image_cropper (0.0.3):
+    - Flutter
+    - TOCropViewController (~> 2.5.4)
   - image_picker (0.0.1):
     - Flutter
   - nanopb (2.30907.0):
@@ -83,6 +86,7 @@ PODS:
   - PromisesObjC (1.2.12)
   - share (0.0.1):
     - Flutter
+  - TOCropViewController (2.5.5)
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -92,6 +96,7 @@ DEPENDENCIES:
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.3.0`)
   - Flutter (from `Flutter`)
+  - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - share (from `.symlinks/plugins/share/ios`)
@@ -109,6 +114,7 @@ SPEC REPOS:
     - GTMSessionFetcher
     - nanopb
     - PromisesObjC
+    - TOCropViewController
 
 EXTERNAL SOURCES:
   cloud_firestore:
@@ -126,6 +132,8 @@ EXTERNAL SOURCES:
     :tag: 7.3.0
   Flutter:
     :path: Flutter
+  image_cropper:
+    :path: ".symlinks/plugins/image_cropper/ios"
   image_picker:
     :path: ".symlinks/plugins/image_picker/ios"
   package_info:
@@ -155,11 +163,13 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
+  image_cropper: c8f9b4157933c7bb965a66d1c5e6c8fd408c6eb4
   image_picker: 9c3312491f862b28d21ecd8fdf0ee14e601b3f09
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   share: 0b2c3e82132f5888bccca3351c504d0003b3b410
+  TOCropViewController: da59f531f8ac8a94ef6d6c0fc34009350f9e8bfe
 
 PODFILE CHECKSUM: db0e0c4708dc6c34a9e9f4381b29af2669471720
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -71,6 +71,8 @@ PODS:
   - GoogleUtilities/Reachability (7.2.2):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.5.0)
+  - image_picker (0.0.1):
+    - Flutter
   - nanopb (2.30907.0):
     - nanopb/decode (= 2.30907.0)
     - nanopb/encode (= 2.30907.0)
@@ -90,6 +92,7 @@ DEPENDENCIES:
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.3.0`)
   - Flutter (from `Flutter`)
+  - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - share (from `.symlinks/plugins/share/ios`)
 
@@ -123,6 +126,8 @@ EXTERNAL SOURCES:
     :tag: 7.3.0
   Flutter:
     :path: Flutter
+  image_picker:
+    :path: ".symlinks/plugins/image_picker/ios"
   package_info:
     :path: ".symlinks/plugins/package_info/ios"
   share:
@@ -150,6 +155,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
+  image_picker: 9c3312491f862b28d21ecd8fdf0ee14e601b3f09
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -56,5 +56,11 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+    <key>NSCameraUsageDescription</key>
+    <string>Used to customize profile image.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Used to customize profile image with pictures taked with camera.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Used to customize profile image with pictures in photo library.</string>
 </dict>
 </plist>

--- a/lib/repository/user_repository.dart
+++ b/lib/repository/user_repository.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:projecthit/entity/app_setting.dart';
 import 'package:projecthit/extension/document_reference.dart';
@@ -8,6 +11,7 @@ import 'package:projecthit/entity/app_user.dart';
 class UserRepository {
   final _auth = FirebaseAuth.instance;
   final _store = FirebaseFirestore.instance;
+  final _storage = FirebaseStorage.instance;
 
   User get currentUser => _auth.currentUser;
 
@@ -118,5 +122,23 @@ class UserRepository {
 
   Future<void> sendPasswordResetEmail(String email) async {
     await _auth.sendPasswordResetEmail(email: email);
+  }
+
+  Future<String> uploadProfileImage({File imageFile}) async {
+    final profileImageFileRef = _storage
+        .ref()
+        .child('users')
+        .child(_auth.currentUser.uid)
+        .child('images')
+        .child('profile.jpg');
+
+    final uploadTask = await profileImageFileRef.putFile(
+      imageFile,
+      SettableMetadata(
+        contentType: 'image/jpg',
+      ),
+    );
+
+    return await uploadTask.ref.getDownloadURL();
   }
 }

--- a/lib/screens/profile/profile_model.dart
+++ b/lib/screens/profile/profile_model.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:projecthit/entity/app_user.dart';
 import 'package:projecthit/repository/user_repository.dart';
@@ -28,10 +29,35 @@ class ProfileModel extends ChangeNotifier {
     await _userRepository.signOut();
   }
 
-  Future<void> imagePicker({ImageSource source}) async {
-    final _picker = ImagePicker();
-    final pickedFile = await _picker.getImage(source: source);
-    profileImageFile = File(pickedFile.path);
+  Future<void> profileImagePicker({ImageSource source}) async {
+    final pickedFile = await _imagePicker(source: source);
+
+    if (pickedFile == null) return;
+
+    profileImageFile = await _imageCropper(sourcePath: pickedFile.path);
     notifyListeners();
+  }
+
+  Future<PickedFile> _imagePicker({ImageSource source}) async {
+    final _picker = ImagePicker();
+    return await _picker.getImage(source: source);
+  }
+
+  Future<File> _imageCropper({String sourcePath}) async {
+    return await ImageCropper.cropImage(
+      sourcePath: sourcePath,
+      aspectRatio: CropAspectRatio(ratioX: 1, ratioY: 1),
+      cropStyle: CropStyle.circle,
+      compressQuality: 90, // 画像圧縮の品質
+      aspectRatioPresets: [
+        CropAspectRatioPreset.square,
+      ],
+      androidUiSettings: AndroidUiSettings(
+        initAspectRatio: CropAspectRatioPreset.square,
+      ),
+      iosUiSettings: IOSUiSettings(
+        minimumAspectRatio: 1.0,
+      ),
+    );
   }
 }

--- a/lib/screens/profile/profile_model.dart
+++ b/lib/screens/profile/profile_model.dart
@@ -1,10 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:projecthit/entity/app_user.dart';
 import 'package:projecthit/repository/user_repository.dart';
 
 class ProfileModel extends ChangeNotifier {
   final _userRepository = UserRepository();
   bool isLoading = false;
+  File profileImageFile;
 
   void beginLoading() {
     isLoading = true;
@@ -22,5 +26,12 @@ class ProfileModel extends ChangeNotifier {
 
   Future<void> signOut() async {
     await _userRepository.signOut();
+  }
+
+  Future<void> imagePicker({ImageSource source}) async {
+    final _picker = ImagePicker();
+    final pickedFile = await _picker.getImage(source: source);
+    profileImageFile = File(pickedFile.path);
+    notifyListeners();
   }
 }

--- a/lib/screens/profile/profile_page.dart
+++ b/lib/screens/profile/profile_page.dart
@@ -136,7 +136,10 @@ class Profile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<ProfileModel>(
-      create: (_) => ProfileModel(),
+      create: (context) {
+        final currentAppUser = context.read<MyAppModel>().currentAppUser;
+        return ProfileModel(currentAppUser);
+      },
       builder: (context, child) {
         final profileModel = context.read<ProfileModel>();
         final myAppModel = context.read<MyAppModel>();
@@ -309,7 +312,29 @@ class _ProfileImage extends StatelessWidget {
             minimumSize: Size(40, 40),
           ),
           onPressed: () async {
-            await profileModel.profileImagePicker(source: ImageSource.gallery);
+            try {
+              await profileModel.profileImagePickerAndUpload(
+                source: ImageSource.gallery,
+              );
+            } catch (e) {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return AlertDialog(
+                    title: Text('Oops!'),
+                    content: Text('$e'),
+                    actions: [
+                      TextButton(
+                        child: Text('OK'),
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                      ),
+                    ],
+                  );
+                },
+              );
+            }
           },
         ),
       ],

--- a/lib/screens/profile/profile_page.dart
+++ b/lib/screens/profile/profile_page.dart
@@ -309,7 +309,7 @@ class _ProfileImage extends StatelessWidget {
             minimumSize: Size(40, 40),
           ),
           onPressed: () async {
-            await profileModel.imagePicker(source: ImageSource.gallery);
+            await profileModel.profileImagePicker(source: ImageSource.gallery);
           },
         ),
       ],

--- a/lib/screens/profile/profile_page.dart
+++ b/lib/screens/profile/profile_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:projecthit/screens/auth/auth_page.dart';
 import 'package:projecthit/screens/my_app/my_app_model.dart';
 import 'package:projecthit/screens/profile/profile_model.dart';
@@ -163,42 +164,7 @@ class Profile extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Center(
-                        child: Stack(
-                          alignment: Alignment.bottomRight,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.all(4),
-                              child: Container(
-                                width: 100,
-                                height: 100,
-                                alignment: Alignment.center,
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  border: Border.all(
-                                    color: Theme.of(context).dividerColor,
-                                  ),
-                                ),
-                                child: Icon(
-                                  Icons.face_outlined,
-                                ),
-                              ),
-                            ),
-                            ElevatedButton(
-                              child: Icon(
-                                Icons.photo_camera_outlined,
-                                size: 20,
-                              ),
-                              style: ElevatedButton.styleFrom(
-                                shape: CircleBorder(),
-                                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                                minimumSize: Size(40, 40),
-                              ),
-                              onPressed: () {
-                                // TODO: アイコン変更
-                              },
-                            ),
-                          ],
-                        ),
+                        child: _ProfileImage(),
                       ),
                       SizedBox(height: 16),
                       Text(
@@ -287,6 +253,66 @@ class Profile extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+}
+
+class _ProfileImage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final profileModel = context.read<ProfileModel>();
+
+    return Stack(
+      alignment: Alignment.bottomRight,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(4),
+          child: Container(
+            width: 140,
+            height: 140,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: Theme.of(context).dividerColor,
+              ),
+              image: context.select(
+                (ProfileModel model) => model.profileImageFile != null,
+              )
+                  ? DecorationImage(
+                      image: FileImage(profileModel.profileImageFile),
+                      fit: BoxFit.cover,
+                    )
+                  : null,
+            ),
+            child: context.select(
+              (ProfileModel model) => model.profileImageFile != null,
+            )
+                ? null
+                : Text(
+                    'Image',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Theme.of(context).textTheme.caption.color,
+                    ),
+                  ),
+          ),
+        ),
+        ElevatedButton(
+          child: Icon(
+            Icons.photo_camera_outlined,
+            size: 20,
+          ),
+          style: ElevatedButton.styleFrom(
+            shape: CircleBorder(),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            minimumSize: Size(40, 40),
+          ),
+          onPressed: () async {
+            await profileModel.imagePicker(source: ImageSource.gallery);
+          },
+        ),
+      ],
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  image_cropper:
+    dependency: "direct main"
+    description:
+      name: image_cropper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -198,6 +205,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.7+22"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.6"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   firebase_dynamic_links: ^0.7.0+1
   english_words: ^3.1.5
   share: ^0.6.5+4
+  image_picker: ^0.6.7+22
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   english_words: ^3.1.5
   share: ^0.6.5+4
   image_picker: ^0.6.7+22
+  image_cropper: ^1.3.1
 
 dev_dependencies:
   flutter_test:

--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,13 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read, write: if request.auth!=null;
+    match /users/{userId}/images/{imageId} {
+      allow get: if request.auth.uid != null
+        && request.auth.uid == userId
+      allow create: if request.auth.uid != null
+        && request.auth.uid == userId
+        && request.resource.size < 10 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*');
     }
   }
 }


### PR DESCRIPTION
## 作業内容
- ローカルから写真を選択できる機能の作成
- 選択した写真をトリミングできる機能の作成
- 写真をFirebase Storageにアップロードする機能の作成

## 確認手順
1. プロフィール画面で画像をアップロードし、Firestoreにプロフィール写真のURLが保存される。

## Issue
#75 