### PR TITLE
プロジェクト存在チェック用画面を作成

### DIFF
--- a/lib/screens/add_project/add_project_page.dart
+++ b/lib/screens/add_project/add_project_page.dart
@@ -15,9 +15,9 @@ class AddProject extends StatelessWidget {
 
     try {
       addProjectModel.beginLoading();
-      await addProjectModel.addProject(name: name);
+      // await addProjectModel.addProject(name: name);
       addProjectModel.endLoading();
-      Navigator.pop(context);
+      // TODO: タスク一覧画面へ
     } catch (e) {
       addProjectModel.endLoading();
       showDialog(

--- a/lib/screens/auth/auth_page.dart
+++ b/lib/screens/auth/auth_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:projecthit/screens/auth/auth_model.dart';
 import 'package:projecthit/screens/my_app/my_app_model.dart';
-import 'package:projecthit/screens/project_list/project_list_page.dart';
 import 'package:projecthit/screens/sign_in/sign_in_page.dart';
+import 'package:projecthit/screens/welcome/welcome_page.dart';
 import 'package:provider/provider.dart';
 
 class Auth extends StatelessWidget {
@@ -86,7 +86,7 @@ class Auth extends StatelessWidget {
                                     Navigator.pushReplacement(
                                       context,
                                       MaterialPageRoute(
-                                        builder: (context) => ProjectList(),
+                                        builder: (context) => Welcome(),
                                       ),
                                     );
                                   } catch (e) {

--- a/lib/screens/my_app/my_app_page.dart
+++ b/lib/screens/my_app/my_app_page.dart
@@ -4,7 +4,7 @@ import 'package:projecthit/model/theme_model.dart';
 import 'package:projecthit/screens/accept_invitation/accept_invitation_page.dart';
 import 'package:projecthit/screens/auth/auth_page.dart';
 import 'package:projecthit/screens/my_app/my_app_model.dart';
-import 'package:projecthit/screens/project_list/project_list_page.dart';
+import 'package:projecthit/screens/welcome/welcome_page.dart';
 import 'package:projecthit/theme/theme_data.dart';
 import 'package:provider/provider.dart';
 
@@ -58,7 +58,7 @@ class _MyAppState extends State<MyApp> {
           theme: context.select((ThemeModel model) => model.isDarkMode)
               ? darkThemeData
               : lightThemeData,
-          home: myAppModel.currentUser != null ? ProjectList() : Auth(),
+          home: myAppModel.currentUser != null ? Welcome() : Auth(),
         );
       },
     );

--- a/lib/screens/welcome/welcome_model.dart
+++ b/lib/screens/welcome/welcome_model.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:projecthit/entity/project.dart';
+
+class WelcomeModel extends ChangeNotifier {
+  Project project;
+
+  Future<void> fetchProject() async {
+    // TODO: プロジェクト取得処理（以下は仮の実装）
+    await Future.delayed(Duration(milliseconds: 3000));
+  }
+}

--- a/lib/screens/welcome/welcome_page.dart
+++ b/lib/screens/welcome/welcome_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:projecthit/screens/add_project/add_project_page.dart';
+import 'package:projecthit/screens/task_list/task_list_page.dart';
+import 'package:projecthit/screens/welcome/welcome_model.dart';
+import 'package:provider/provider.dart';
+
+class Welcome extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<WelcomeModel>(
+      create: (_) => WelcomeModel(),
+      builder: (context, snapshot) {
+        final welcomeModel = context.read<WelcomeModel>();
+
+        return Scaffold(
+          body: FutureBuilder(
+            future: welcomeModel.fetchProject(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              }
+
+              if (snapshot.hasError) {
+                return Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Center(
+                    child: Text('${snapshot.error}'),
+                  ),
+                );
+              }
+
+              final project = context.select(
+                (WelcomeModel model) => model.project,
+              );
+
+              return project != null
+                  ? TaskList(project: project)
+                  : AddProject();
+            },
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 作業内容
- プロジェクト存在チェック用画面(welcome_page.dart)を作成
- 作成した画面のViewModel(welcome_model.dart)を追加し、仮の処理を作成
- ユーザー登録後の遷移先を変更
- ログイン後の遷移先を変更

## 確認して欲しい点
- ユーザー登録後にプロジェクト作成画面が表示されること。（現状はプロジェクトを作成後も画面遷移をせず、複数のプロジェクトを作成できてしまいます。）
- 上記の理由で、プロジェクト作成機能はコメントアウトしています。

## Issue
#84 