### PR TITLE
通知機能の作成

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -75,6 +75,7 @@ service cloud.firestore {
         match /tokens/{tokenId} {
           allow create: if isAuthenticatedUser(userId)
             && request.resource.data.size() == 0;
+          allow delete: if isAuthenticatedUser(userId);
         }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -71,6 +71,11 @@ service cloud.firestore {
           allow get: if isAuthenticatedUser(userId);
           allow update: if isAuthenticatedUser(userId);
         }
+
+        match /tokens/{tokenId} {
+          allow create: if isAuthenticatedUser(userId)
+            && request.resource.data.size() == 0;
+        }
     }
 
     match /projects/{projectId} {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -14,6 +14,9 @@ PODS:
   - Firebase/Firestore (7.3.0):
     - Firebase/CoreOnly
     - FirebaseFirestore (~> 7.3.0)
+  - Firebase/Messaging (7.3.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 7.3.0)
   - Firebase/Storage (7.3.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 7.3.0)
@@ -26,6 +29,10 @@ PODS:
     - Flutter
   - firebase_dynamic_links (0.7.0-1):
     - Firebase/DynamicLinks (= 7.3.0)
+    - firebase_core
+    - Flutter
+  - firebase_messaging (8.0.0-dev.15):
+    - Firebase/Messaging (= 7.3.0)
     - firebase_core
     - Flutter
   - firebase_storage (7.0.0):
@@ -49,6 +56,23 @@ PODS:
   - FirebaseDynamicLinks (7.3.1):
     - FirebaseCore (~> 7.0)
   - FirebaseFirestore (7.3.0)
+  - FirebaseInstallations (7.6.0):
+    - FirebaseCore (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
+    - PromisesObjC (~> 1.2)
+  - FirebaseInstanceID (7.9.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
+  - FirebaseMessaging (7.3.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstanceID (~> 7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Reachability (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
   - FirebaseStorage (7.3.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
@@ -72,6 +96,8 @@ PODS:
     - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.2.2)"
   - GoogleUtilities/Reachability (7.2.2):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (7.2.2):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.5.0)
   - image_cropper (0.0.3):
@@ -101,6 +127,7 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_dynamic_links (from `.symlinks/plugins/firebase_dynamic_links/ios`)
+  - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.3.0`)
   - Flutter (from `Flutter`)
@@ -118,6 +145,9 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseDynamicLinks
+    - FirebaseInstallations
+    - FirebaseInstanceID
+    - FirebaseMessaging
     - FirebaseStorage
     - FMDB
     - GoogleDataTransport
@@ -136,6 +166,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_dynamic_links:
     :path: ".symlinks/plugins/firebase_dynamic_links/ios"
+  firebase_messaging:
+    :path: ".symlinks/plugins/firebase_messaging/ios"
   firebase_storage:
     :path: ".symlinks/plugins/firebase_storage/ios"
   FirebaseFirestore:
@@ -167,12 +199,16 @@ SPEC CHECKSUMS:
   firebase_auth: 7220e26fc14a501a63093edc10443de6bca0d7e8
   firebase_core: 91b27774a52f41f8b58484a75edf71197ac01c59
   firebase_dynamic_links: 14bf04008446c471b5c9f6e6542e14210bf26bd5
+  firebase_messaging: caf0273c76e54f0a10dfe5048ac47b89e75bb78a
   firebase_storage: 554b8ce9192bfe0bd35f63da42d0d1f6ae819ccc
   FirebaseAuth: c224a0cf1afa0949bd5c7bfcf154b4f5ce8ddef2
   FirebaseCore: 4d3c72622ce0e2106aaa07bb4b2935ba2c370972
   FirebaseCoreDiagnostics: ee1184d51da3293335b83355aad20f537acc24cf
   FirebaseDynamicLinks: a6df95d6dbc746c2bbf7d511343cda1344e2cf70
   FirebaseFirestore: 46e32f479aac127e742b1cf873930f7bb43e7b45
+  FirebaseInstallations: 6e4e77396559bc2ae0504823837ed737b1c7e47f
+  FirebaseInstanceID: 53140c03b9f6136f890d7901399f85a4c90ab2d0
+  FirebaseMessaging: 68d1bcb14880189558a8ae57167abe0b7e417232
   FirebaseStorage: 5002b1895bfe74a5ce92ad54f966e6162d0da2e5
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,4 +10,8 @@ import Flutter
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  override func applicationDidBecomeActive(_ application: UIApplication) {
+    UIApplication.shared.applicationIconBadgeNumber = 0
+  }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -37,6 +37,17 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to customize profile image.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Used to customize profile image with pictures taked with camera.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to customize profile image with pictures in photo library.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -56,11 +67,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-    <key>NSCameraUsageDescription</key>
-    <string>Used to customize profile image.</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>Used to customize profile image with pictures taked with camera.</string>
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>Used to customize profile image with pictures in photo library.</string>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:projecthitdev.page.link</string>

--- a/lib/repository/user_repository.dart
+++ b/lib/repository/user_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:projecthit/entity/app_setting.dart';
@@ -12,6 +13,7 @@ class UserRepository {
   final _auth = FirebaseAuth.instance;
   final _store = FirebaseFirestore.instance;
   final _storage = FirebaseStorage.instance;
+  final _messaging = FirebaseMessaging.instance;
 
   User get currentUser => _auth.currentUser;
 
@@ -135,6 +137,13 @@ class UserRepository {
   }
 
   Future<void> signOut() async {
+    final token = await _messaging.getToken();
+    await _store
+        .collection('users')
+        .doc(_auth.currentUser.uid)
+        .collection('tokens')
+        .doc(token)
+        .delete();
     await _auth.signOut();
   }
 

--- a/lib/repository/user_token_repository.dart
+++ b/lib/repository/user_token_repository.dart
@@ -1,0 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class UserTokenRepository {
+  FirebaseFirestore _store = FirebaseFirestore.instance;
+  FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Future<void> add(String token) async {
+    await _store
+        .collection('users')
+        .doc(_auth.currentUser.uid)
+        .collection('tokens')
+        .doc(token)
+        .set({});
+  }
+}

--- a/lib/screens/my_app/my_app_model.dart
+++ b/lib/screens/my_app/my_app_model.dart
@@ -1,12 +1,16 @@
 import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:projecthit/entity/app_user.dart';
 import 'package:projecthit/repository/user_repository.dart';
+import 'package:projecthit/repository/user_token_repository.dart';
 
 class MyAppModel extends ChangeNotifier {
   final _userRepository = UserRepository();
+  final _userTokenRepository = UserTokenRepository();
+  final _messaging = FirebaseMessaging.instance;
   User currentUser;
   AppUser currentAppUser;
   StreamSubscription<User> userSubscription;
@@ -37,6 +41,19 @@ class MyAppModel extends ChangeNotifier {
   Future<void> fetchCurrentUser() async {
     currentUser = _userRepository.currentUser;
     notifyListeners();
+  }
+
+  Future<void> initCloudMessaging() async {
+    await _messaging.requestPermission();
+
+    final token = await _messaging.getToken();
+
+    // documentIdにトークンを指定しているので既に作成済みだとエラーが出る。
+    try {
+      await _userTokenRepository.add(token);
+    } catch (e) {
+      return;
+    }
   }
 
   @override

--- a/lib/screens/task_detail/task_detail_page.dart
+++ b/lib/screens/task_detail/task_detail_page.dart
@@ -30,16 +30,21 @@ class TaskDetail extends StatelessWidget {
         ? Timestamp.fromDate(DateTime.parse(deadline))
         : null;
 
-    task.name = name;
-    task.description = description;
-    task.expiredAt = expiredAt;
-
     FocusScope.of(context).unfocus();
 
     final taskDetailModel = context.read<TaskDetailModel>();
 
     try {
       taskDetailModel.beginLoading();
+
+      if (expiredAt != null && taskDetailModel.projectTaskUserIds.isEmpty) {
+        throw ('Please select a user to notify reminder.');
+      }
+
+      task.name = name;
+      task.description = description;
+      task.expiredAt = expiredAt;
+
       await taskDetailModel.updateTask(
         project: project,
         task: task,

--- a/lib/screens/task_list/task_list_page.dart
+++ b/lib/screens/task_list/task_list_page.dart
@@ -7,17 +7,23 @@ import 'package:projecthit/extension/date_time.dart';
 import 'package:projecthit/entity/project.dart';
 import 'package:projecthit/entity/task.dart';
 import 'package:projecthit/screens/add_task/add_task_page.dart';
+import 'package:projecthit/screens/my_app/my_app_model.dart';
 import 'package:projecthit/screens/project_detail/project_detail_page.dart';
 import 'package:projecthit/screens/setting/setting_page.dart';
 import 'package:projecthit/screens/task_detail/task_detail_page.dart';
 import 'package:projecthit/screens/task_list/task_list_model.dart';
 import 'package:provider/provider.dart';
 
-class TaskList extends StatelessWidget {
+class TaskList extends StatefulWidget {
   final Project project;
 
   TaskList({@required this.project});
 
+  @override
+  _TaskListState createState() => _TaskListState();
+}
+
+class _TaskListState extends State<TaskList> {
   Future<void> _doneTask(BuildContext context, Task task) async {
     final taskListModel = context.read<TaskListModel>();
 
@@ -106,6 +112,19 @@ class TaskList extends StatelessWidget {
   }
 
   @override
+  void initState() {
+    super.initState();
+
+    final myAppModel = context.read<MyAppModel>();
+
+    Future(
+      () async {
+        await myAppModel.initCloudMessaging();
+      },
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final viewPadding = MediaQuery.of(context).viewPadding;
 
@@ -116,7 +135,7 @@ class TaskList extends StatelessWidget {
     }
 
     return ChangeNotifierProvider<TaskListModel>(
-      create: (_) => TaskListModel(project: project),
+      create: (_) => TaskListModel(project: widget.project),
       builder: (context, snapshot) {
         final taskListModel = context.read<TaskListModel>();
 
@@ -124,7 +143,7 @@ class TaskList extends StatelessWidget {
           children: [
             Scaffold(
               appBar: AppBar(
-                title: Text('${project.name}'),
+                title: Text('${widget.project.name}'),
                 actions: [
                   IconButton(
                     icon: Icon(Icons.delete_outline),
@@ -137,7 +156,8 @@ class TaskList extends StatelessWidget {
                     onPressed: () => Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => ProjectDetail(project: project),
+                        builder: (context) =>
+                            ProjectDetail(project: widget.project),
                       ),
                     ),
                   ),
@@ -284,7 +304,7 @@ class TaskList extends StatelessWidget {
                               context,
                               MaterialPageRoute(
                                 builder: (context) => TaskDetail(
-                                  project: project,
+                                  project: widget.project,
                                   task: task,
                                 ),
                               ),
@@ -305,7 +325,7 @@ class TaskList extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       fullscreenDialog: true,
-                      builder: (context) => AddTask(project: project),
+                      builder: (context) => AddTask(project: widget.project),
                     ),
                   );
                 },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -183,6 +183,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.0+1"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.0-dev.15"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.10"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-dev.6"
   firebase_storage:
     dependency: "direct main"
     description:
@@ -443,6 +464,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.25.0"
+  service_worker:
+    dependency: transitive
+    description:
+      name: service_worker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.4"
   share:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   cloud_firestore: ^0.16.0+1
   firebase_storage: ^7.0.0
   firebase_dynamic_links: ^0.7.0+1
+  firebase_messaging: ^8.0.0-dev.15
   english_words: ^3.1.5
   share: ^0.6.5+4
   image_picker: ^0.6.7+22


### PR DESCRIPTION
## 作業内容
- 初回起動時に通知許可確認をする機能の作成
- デバイストークンをFirestoreに保存、削除する機能の作成
- 起動もしくは復帰時にバッジが削除するメソッドを追加
- リマインダーを設定していると、ユーザーの選択が必須になるように修正

## 確認して欲しい点
- デバイストークンの保存方法が適切かどうか（document idにトークンを指定することに問題ないか）
- ユーザーが選択されてない時に、リマインダーを設定するとエラーが発生すること

## Issue
#14 