### PR TITLE
ログイン後のナビゲーションを修正

### DIFF
--- a/lib/screens/sign_in/sign_in_page.dart
+++ b/lib/screens/sign_in/sign_in_page.dart
@@ -45,6 +45,7 @@ class SignIn extends StatelessWidget {
                         await myAppModel.fetchCurrentUser();
                         signInModel.endLoading();
 
+                        Navigator.popUntil(context, (route) => route.isFirst);
                         Navigator.pushReplacement(
                           context,
                           MaterialPageRoute(


### PR DESCRIPTION
## 作業内容
ログインに成功するとサインイン画面を閉じる処理を追加

## 確認して欲しい点
ログイン後に前の画面に戻れないこと。

## Issue
#93 