### PR TITLE
タスク並び替え機能の作成

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -84,8 +84,8 @@ service cloud.firestore {
       allow get: if isAnyAuthenticated()
         && exists(/databases/$(database)/documents/projects/$(projectId)/projectUsers/$(request.auth.uid));
       allow create: if isAnyAuthenticated()
-        && request.resource.data.keys().hasAll(['name', 'description', 'adminUser', 'sumUsers', 'createdAt'])
-        && request.resource.data.keys().hasOnly(['name', 'description', 'adminUser', 'sumUsers', 'createdAt'])
+        && request.resource.data.keys().hasAll(['name', 'description', 'adminUser', 'sumUsers', 'sumTasks', 'createdAt'])
+        && request.resource.data.keys().hasOnly(['name', 'description', 'adminUser', 'sumUsers', 'sumTasks', 'createdAt'])
         && request.resource.data.name is string
         && request.resource.data.name.size() >= 1
         && request.resource.data.name.size() <= 50
@@ -95,11 +95,13 @@ service cloud.firestore {
         && request.resource.data.adminUser == request.auth.uid
         && request.resource.data.sumUsers is int
         && request.resource.data.sumUsers == 1
+        && request.resource.data.sumTasks is int
+        && request.resource.data.sumTasks == 0
         && request.resource.data.createdAt is timestamp
         && request.resource.data.createdAt == request.time;
       allow update: if isAnyAuthenticated()
-        && request.resource.data.keys().hasAll(['name', 'description', 'adminUser', 'sumUsers', 'createdAt'])
-        && request.resource.data.keys().hasOnly(['name', 'description', 'adminUser', 'sumUsers', 'createdAt'])
+        && request.resource.data.keys().hasAll(['name', 'description', 'adminUser', 'sumUsers', 'sumTasks', 'createdAt'])
+        && request.resource.data.keys().hasOnly(['name', 'description', 'adminUser', 'sumUsers', 'sumTasks', 'createdAt'])
         && request.resource.data.name is string
         && request.resource.data.name.size() >= 1
         && request.resource.data.name.size() <= 50
@@ -109,6 +111,8 @@ service cloud.firestore {
         && request.resource.data.adminUser == resource.data.adminUser
         && request.resource.data.sumUsers is int
         && request.resource.data.sumUsers >= 1
+        && request.resource.data.sumTasks is int
+        && request.resource.data.sumTasks >= 0
         && request.resource.data.createdAt is timestamp
         && request.resource.data.createdAt == resource.data.createdAt;
       allow delete: if isAnyAuthenticated()

--- a/firestore.rules
+++ b/firestore.rules
@@ -133,8 +133,8 @@ service cloud.firestore {
       match /projectTasks/{projectTaskId} {
         allow list: if isAnyAuthenticated();
         allow create: if isAnyAuthenticated()
-          && request.resource.data.keys().hasAll(['name', 'description', 'isDone', 'taskUserIds', 'expiredAt', 'createdAt'])
-          && request.resource.data.keys().hasOnly(['name', 'description', 'isDone', 'taskUserIds', 'expiredAt', 'createdAt'])
+          && request.resource.data.keys().hasAll(['name', 'description', 'isDone', 'taskUserIds', 'sortKey', 'expiredAt', 'createdAt'])
+          && request.resource.data.keys().hasOnly(['name', 'description', 'isDone', 'taskUserIds', 'sortKey', 'expiredAt', 'createdAt'])
           && request.resource.data.name is string
           && request.resource.data.name.size() >= 1
           && request.resource.data.name.size() <= 100
@@ -145,10 +145,12 @@ service cloud.firestore {
           && request.resource.data.taskUserIds is list
           && request.resource.data.expiredAt == null
           && request.resource.data.createdAt is timestamp
-          && request.resource.data.createdAt == request.time;
+          && request.resource.data.createdAt == request.time
+          && request.resource.data.sortKey is int
+          && request.resource.data.sortKey >= 0;
         allow update: if isAnyAuthenticated()
-          && request.resource.data.keys().hasAll(['name', 'description', 'isDone', 'taskUserIds', 'expiredAt', 'createdAt'])
-          && request.resource.data.keys().hasOnly(['name', 'description', 'isDone', 'taskUserIds', 'expiredAt', 'createdAt'])
+          && request.resource.data.keys().hasAll(['name', 'description', 'isDone', 'taskUserIds', 'sortKey', 'expiredAt', 'createdAt'])
+          && request.resource.data.keys().hasOnly(['name', 'description', 'isDone', 'taskUserIds', 'sortKey', 'expiredAt', 'createdAt'])
           && request.resource.data.name is string
           && request.resource.data.name.size() >= 1
           && request.resource.data.name.size() <= 100
@@ -158,7 +160,9 @@ service cloud.firestore {
           && request.resource.data.taskUserIds is list
           && (request.resource.data.expiredAt == null || (request.resource.data.expiredAt is timestamp && request.resource.data.expiredAt.toMillis() > resource.data.createdAt.toMillis()))
           && request.resource.data.createdAt is timestamp
-          && request.resource.data.createdAt == resource.data.createdAt;
+          && request.resource.data.createdAt == resource.data.createdAt
+          && request.resource.data.sortKey is int
+          && request.resource.data.sortKey >= 0;
         allow delete: if isAnyAuthenticated();
       }
     }

--- a/lib/entity/project.dart
+++ b/lib/entity/project.dart
@@ -6,6 +6,7 @@ class Project {
   String name;
   String description;
   int sumUsers;
+  int sumTasks;
   String adminUser;
   Timestamp createdAt;
 
@@ -16,6 +17,7 @@ class Project {
     name = map[ProjectField.name];
     description = map[ProjectField.description];
     sumUsers = map[ProjectField.sumUsers] as int;
+    sumTasks = map[ProjectField.sumTasks] as int;
     adminUser = map[ProjectField.adminUser];
     createdAt = map[ProjectField.createdAt] as Timestamp;
   }
@@ -26,6 +28,7 @@ class Project {
       ProjectField.name: name,
       ProjectField.description: description,
       ProjectField.sumUsers: sumUsers,
+      ProjectField.sumTasks: sumTasks ?? 0,
       ProjectField.adminUser: adminUser,
       ProjectField.createdAt: createdAt ?? FieldValue.serverTimestamp(),
     };

--- a/lib/entity/project_field.dart
+++ b/lib/entity/project_field.dart
@@ -4,5 +4,6 @@ class ProjectField {
   static const description = 'description';
   static const adminUser = 'adminUser';
   static const sumUsers = 'sumUsers';
+  static const sumTasks = 'sumTasks';
   static const createdAt = 'createdAt';
 }

--- a/lib/entity/task.dart
+++ b/lib/entity/task.dart
@@ -7,6 +7,7 @@ class Task {
   String description;
   bool isDone;
   List<String> taskUserIds;
+  int sortKey;
   Timestamp expiredAt;
   Timestamp createdAt;
 
@@ -26,6 +27,7 @@ class Task {
     taskUserIds = (map[TaskField.taskUserIds] as List)
         .map((userId) => userId as String)
         .toList();
+    sortKey = map[TaskField.sortKey];
     expiredAt = map[TaskField.expiredAt];
     createdAt = map[TaskField.createdAt];
   }
@@ -36,6 +38,7 @@ class Task {
       TaskField.description: description ?? '',
       TaskField.isDone: isDone ?? false,
       TaskField.taskUserIds: taskUserIds ?? [],
+      TaskField.sortKey: sortKey,
       TaskField.expiredAt: expiredAt,
       TaskField.createdAt: createdAt ?? FieldValue.serverTimestamp(),
     };

--- a/lib/entity/task_field.dart
+++ b/lib/entity/task_field.dart
@@ -4,6 +4,7 @@ class TaskField {
   static const description = 'description';
   static const isDone = 'isDone';
   static const taskUserIds = 'taskUserIds';
+  static const sortKey = 'sortKey';
   static const expiredAt = 'expiredAt';
   static const createdAt = 'createdAt';
 }

--- a/lib/screens/add_task/add_task_model.dart
+++ b/lib/screens/add_task/add_task_model.dart
@@ -25,6 +25,7 @@ class AddTaskModel extends ChangeNotifier {
   }) async {
     final task = Task();
     task.name = name;
+    task.sortKey = project.sumTasks;
     await _taskRepository.addTask(project, task);
   }
 }

--- a/lib/screens/task_list/task_list_model.dart
+++ b/lib/screens/task_list/task_list_model.dart
@@ -38,4 +38,8 @@ class TaskListModel extends ChangeNotifier {
   Stream<List<AppUser>> fetchTaskUsers(List<String> userIds) {
     return _userRepository.fetchUsers(userIds);
   }
+
+  Future<void> sortTasks(Project project, List<Task> taskList) async {
+    await _taskRepository.sortTasks(project, taskList);
+  }
 }

--- a/lib/screens/task_list/task_list_page.dart
+++ b/lib/screens/task_list/task_list_page.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:implicitly_animated_reorderable_list/implicitly_animated_reorderable_list.dart';
+import 'package:implicitly_animated_reorderable_list/transitions.dart';
 import 'package:outline_material_icons/outline_material_icons.dart';
 import 'package:projecthit/entity/app_user.dart';
 import 'package:projecthit/extension/date_time.dart';
@@ -359,94 +360,97 @@ class _TaskList extends StatelessWidget {
       itemBuilder: (context, itemAnimation, item, index) {
         return Reorderable(
           key: ValueKey(item.id),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Handle(
-              delay: Duration(milliseconds: 500),
-              child: Material(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  side: BorderSide(
-                    color: Theme.of(context).dividerColor,
-                  ),
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: InkWell(
-                  child: Padding(
-                    padding: const EdgeInsets.all(10),
-                    child: Row(
-                      children: [
-                        OutlinedButton(
-                          child: Icon(
-                            Icons.circle,
-                            size: item.isDone ? 24 : 0,
-                          ),
-                          style: OutlinedButton.styleFrom(
-                            shape: CircleBorder(),
-                            padding: EdgeInsets.zero,
-                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            minimumSize: Size(34, 34),
-                          ),
-                          onPressed: () async {
-                            await _doneTask(context, item);
-                          },
-                        ),
-                        SizedBox(width: 10),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                '${item.name}',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .subtitle1
-                                    .copyWith(
-                                      decoration: item.isDone
-                                          ? TextDecoration.lineThrough
-                                          : null,
-                                      color: item.isDone
-                                          ? Theme.of(context)
-                                              .textTheme
-                                              .caption
-                                              .color
-                                          : null,
-                                    ),
-                              ),
-                              if (item.expiredAt != null) SizedBox(height: 4),
-                              if (item.expiredAt != null)
-                                Text(
-                                  '${item.expiredAt.toDate().format()}',
-                                  style: TextStyle(
-                                    color: item.isExpired && !item.isDone
-                                        ? Color(0xFFEF377A)
-                                        : Theme.of(context)
-                                            .textTheme
-                                            .caption
-                                            .color,
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-                        SizedBox(width: 10),
-                        if (item.taskUserIds.isNotEmpty)
-                          _TaskUserIcon(task: item),
-                      ],
+          child: SizeFadeTransition(
+            animation: itemAnimation,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Handle(
+                delay: Duration(milliseconds: 500),
+                child: Material(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: Theme.of(context).dividerColor,
                     ),
                   ),
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => TaskDetail(
-                          project: project,
-                          task: item,
-                        ),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Row(
+                        children: [
+                          OutlinedButton(
+                            child: Icon(
+                              Icons.circle,
+                              size: item.isDone ? 24 : 0,
+                            ),
+                            style: OutlinedButton.styleFrom(
+                              shape: CircleBorder(),
+                              padding: EdgeInsets.zero,
+                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                              minimumSize: Size(34, 34),
+                            ),
+                            onPressed: () async {
+                              await _doneTask(context, item);
+                            },
+                          ),
+                          SizedBox(width: 10),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  '${item.name}',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .subtitle1
+                                      .copyWith(
+                                        decoration: item.isDone
+                                            ? TextDecoration.lineThrough
+                                            : null,
+                                        color: item.isDone
+                                            ? Theme.of(context)
+                                                .textTheme
+                                                .caption
+                                                .color
+                                            : null,
+                                      ),
+                                ),
+                                if (item.expiredAt != null) SizedBox(height: 4),
+                                if (item.expiredAt != null)
+                                  Text(
+                                    '${item.expiredAt.toDate().format()}',
+                                    style: TextStyle(
+                                      color: item.isExpired && !item.isDone
+                                          ? Color(0xFFEF377A)
+                                          : Theme.of(context)
+                                              .textTheme
+                                              .caption
+                                              .color,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                          SizedBox(width: 10),
+                          if (item.taskUserIds.isNotEmpty)
+                            _TaskUserIcon(task: item),
+                        ],
                       ),
-                    );
-                  },
+                    ),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => TaskDetail(
+                            project: project,
+                            task: item,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -308,6 +308,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  implicitly_animated_reorderable_list:
+    dependency: "direct main"
+    description:
+      name: implicitly_animated_reorderable_list
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.2"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   image_picker: ^0.6.7+22
   image_cropper: ^1.3.1
   cached_network_image: ^2.5.1
+  implicitly_animated_reorderable_list: ^0.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 作業内容
- 並び替え順を記録するorderKeyフィールドをtaskエンティティに追加
- 今まで作成したタスク数を記録するsumTasksフィールドをprojectエンティティに追加
- `implicitly_animated_reorderable_list`を使ってタスクの並び替え機能を作成
- タスクを追加するとsumTasksをインクリメントする処理を追加

## 確認して欲しい点
- 新しいタスクを追加してもタスクの並び順を担保するため、sumTasksフィールドを追加するたびにインクリメントする実装に問題ないか（タスクを削除してもこの値は減らさない）
- タスクを任意に並び替えができること

## Issue
#95 